### PR TITLE
chore: Do not pin slsa-github-generator

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -55,8 +55,15 @@
     {
       groupName: "github-actions",
       matchManagers: ["github-actions"],
+      matchPackageNames: ["!slsa-framework/slsa-github-generator"],
       matchUpdateTypes: ["minor", "patch"],
       pinDigests: true,
+    },
+    {
+      groupName: "github-actions",
+      matchManagers: ["github-actions"],
+      matchPackageNames: ["slsa-framework/slsa-github-generator"],
+      pinDigests: false,
     },
     {
       groupName: "python",


### PR DESCRIPTION
**Description:**

slsa-github-generator should not be pinned by digest due to esoteric limitations in the tokens provided by the GitHub Actions OIDC provider.

See: https://github.com/slsa-framework/slsa-github-generator/?tab=readme-ov-file#referencing-slsa-builders-and-generators
See: https://github.com/slsa-framework/slsa-verifier/issues/12

**Related Issues:**

Fixes #18

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
