### PR TITLE
fix: version extraction from npm

### DIFF
--- a/.github/workflows/generator-container-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-container-ossf-slsa3-publish.yml
@@ -70,14 +70,14 @@ jobs:
         id: package
         run: |
           cd opencode
-          package_version=$(npm list opencode-ai --depth=0 --json | jq -r '.dependencies."opencode-ai".required')
+          package_version=$(npm list --depth=0 --json | jq -r '.dependencies."opencode-ai".required')
           echo "version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ env.IMAGE_REGISTRY }}/opencode
+          images: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}/opencode
           tags: |
             type=raw,value=${{ steps.package.outputs.version }}
 
@@ -151,14 +151,14 @@ jobs:
         id: package
         run: |
           cd claude-code
-          package_version=$(npm list @anthropic-ai/claude-code --depth=0 --json | jq -r '.dependencies."@anthropic-ai/claude-code".required')
+          package_version=$(npm list --depth=1 --json | jq -r '.dependencies."@anthropic-ai/claude-code".required')
           echo "version=${package_version}" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ env.IMAGE_REGISTRY }}/claude-code
+          images: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}/claude-code
           tags: |
             type=raw,value=${{ steps.package.outputs.version }}
 


### PR DESCRIPTION
**Description:**

Fix how versions are extracted using `npm`. If the package isn't installed you can't use `npm list <package-name>` so `npm list` is called without an argument. The version is also listed in the `required` field rather than the `version` field if the package is not installed.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
