### PR TITLE
56 feature shell script launchers

### DIFF
--- a/.github/workflows/generator-container-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-container-ossf-slsa3-publish.yml
@@ -79,6 +79,8 @@ jobs:
         with:
           images: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}/opencode
           tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.package.outputs.version }}
 
       - name: Build and push Docker image
@@ -161,6 +163,8 @@ jobs:
         with:
           images: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}/claude-code
           tags: |
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.package.outputs.version }}
 
       - name: Build and push Docker image

--- a/bin/claude
+++ b/bin/claude
@@ -43,10 +43,7 @@ if ! command -v cosign >/dev/null 2>&1; then
     exit 1
 fi
 
-# renovate: datasource=docker depName=ghcr.io/ianlewis/claude-code versioning=loose
-CLAUDE_CODE_VERSION="1.0.72"
-CLAUDE_CODE_SHA="sha256:bd7c617589facd605bcda06f57a239d1763fdaa0f142c4bbd2d72d94b85c8333"
-CLAUDE_CODE_IMAGE="ghcr.io/ianlewis/claude-code:${CLAUDE_CODE_VERSION}@${CLAUDE_CODE_SHA}"
+CLAUDE_CODE_IMAGE="ghcr.io/ianlewis/claude-code"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
 CLAUDE_DATA_HOME="${XDG_DATA_HOME}/claude-code-docker"

--- a/bin/claude
+++ b/bin/claude
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# vim: set ft=bash:
+#
+# Copyright 2025 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Command claude runs the Claude Code agent in a Docker container using the
+# runsc. The current working directory is mounted into the container. Claude
+# configuration is stored in the directory ${XDG_DATA_HOME}/claude-code-docker.
+
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is not installed. Please install Docker first." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "Please see https://docs.docker.com/engine/install/" >&2
+    exit 1
+fi
+
+runsc_path=$(docker system info --format '{{.Runtimes.runsc.Path}}')
+if [ -z "${runsc_path}" ]; then
+    echo "runsc runtime not found. Please ensure runsc is installed and configured." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "https://gvisor.dev/docs/user_guide/quick_start/docker/" >&2
+    exit 1
+fi
+
+if ! command -v cosign >/dev/null 2>&1; then
+    echo "cosign is not installed. Please install cosign first." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "https://docs.sigstore.dev/cosign/system_config/installation/" >&2
+    exit 1
+fi
+
+# renovate: datasource=docker depName=ghcr.io/ianlewis/claude-code versioning=loose
+CLAUDE_CODE_VERSION="1.0.72"
+CLAUDE_CODE_SHA="sha256:bd7c617589facd605bcda06f57a239d1763fdaa0f142c4bbd2d72d94b85c8333"
+CLAUDE_CODE_IMAGE="ghcr.io/ianlewis/claude-code:${CLAUDE_CODE_VERSION}@${CLAUDE_CODE_SHA}"
+
+XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+CLAUDE_DATA_HOME="${XDG_DATA_HOME}/claude-code-docker"
+
+mkdir -p "${CLAUDE_DATA_HOME}"
+
+# Ensure the .claude.json file exists, as we need to bind mount it into the
+# container.
+if [ ! -f "${CLAUDE_DATA_HOME}/claude.json" ]; then
+    echo "{}" >"${CLAUDE_DATA_HOME}/claude.json"
+fi
+
+cosign verify-attestation \
+    --type slsaprovenance \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+    --policy ~/.config/coding-assistant-docker-images.policy.cue \
+    "${CLAUDE_CODE_IMAGE}"
+
+docker run \
+    --rm \
+    --interactive \
+    --tty \
+    --name claude-code \
+    --runtime runsc \
+    --volume "$(pwd):/workspace" \
+    --volume "${CLAUDE_DATA_HOME}/claude.json:/claude.json" \
+    --volume "${CLAUDE_DATA_HOME}:/claude" \
+    "${CLAUDE_CODE_IMAGE}"

--- a/bin/opencode
+++ b/bin/opencode
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# vim: set ft=bash:
+#
+# Copyright 2025 Ian Lewis
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Command opencode runs the opencode agent in a Docker container using the
+# runsc. The current working directory is mounted into the container. opencode
+# configuration is stored in the directory ${XDG_DATA_HOME}/opencode-docker.
+
+set -euo pipefail
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is not installed. Please install Docker first." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "Please see https://docs.docker.com/engine/install/" >&2
+    exit 1
+fi
+
+runsc_path=$(docker system info --format '{{.Runtimes.runsc.Path}}')
+if [ -z "${runsc_path}" ]; then
+    echo "runsc runtime not found. Please ensure runsc is installed and configured." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "https://gvisor.dev/docs/user_guide/quick_start/docker/" >&2
+    exit 1
+fi
+
+if ! command -v cosign >/dev/null 2>&1; then
+    echo "cosign is not installed. Please install cosign first." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "https://docs.sigstore.dev/cosign/system_config/installation/" >&2
+    exit 1
+fi
+
+# renovate: datasource=docker depName=ghcr.io/ianlewis/opencode versioning=loose
+OPENCODE_VERSION="0.4.14"
+OPENCODE_SHA="sha256:78d314d9bfe965e019644d20657c183ab6767da38ec654a1d37f2e69445b9cd8"
+OPENCODE_IMAGE="ghcr.io/ianlewis/opencode:${OPENCODE_VERSION}@${OPENCODE_SHA}"
+
+XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
+OPENCODE_DATA_HOME="${XDG_DATA_HOME}/opencode-docker"
+
+mkdir -p "${OPENCODE_DATA_HOME}"
+
+cosign verify-attestation \
+    --type slsaprovenance \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+    --policy ~/.config/coding-assistant-docker-images.policy.cue \
+    "${OPENCODE_IMAGE}"
+
+docker run \
+    --rm \
+    --interactive \
+    --tty \
+    --runtime runsc \
+    --name opencode \
+    --volume "$(pwd):/workspace" \
+    --volume "${OPENCODE_DATA_HOME}:/local" \
+    "${OPENCODE_IMAGE}"

--- a/bin/opencode
+++ b/bin/opencode
@@ -43,10 +43,7 @@ if ! command -v cosign >/dev/null 2>&1; then
     exit 1
 fi
 
-# renovate: datasource=docker depName=ghcr.io/ianlewis/opencode versioning=loose
-OPENCODE_VERSION="0.4.14"
-OPENCODE_SHA="sha256:78d314d9bfe965e019644d20657c183ab6767da38ec654a1d37f2e69445b9cd8"
-OPENCODE_IMAGE="ghcr.io/ianlewis/opencode:${OPENCODE_VERSION}@${OPENCODE_SHA}"
+OPENCODE_IMAGE="ghcr.io/ianlewis/opencode"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"
 OPENCODE_DATA_HOME="${XDG_DATA_HOME}/opencode-docker"


### PR DESCRIPTION
**Description:**

Add shell script launchers for `opencode` and `claude`. The launchers require Docker to be installed and `runsc` to be installed as a Docker runtime. Cosign is also required to verify the images before running them.

Images build from main are now given the latest tag.

**Related Issues:**

Fixes #56 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
