### PR TITLE
fix: don't create symlinks twice

### DIFF
--- a/claude-code/entrypoint.sh
+++ b/claude-code/entrypoint.sh
@@ -23,10 +23,6 @@ fi
 
 log "Running as user ID: ${USER_ID}, group ID: ${GROUP_ID}"
 
-# Create a link from the local data directory to the user's home directory.
-ln -sf /claude.json "$(getent passwd "${USER_ID}" | cut -d: -f6)/.claude.json"
-ln -sf /claude "$(getent passwd "${USER_ID}" | cut -d: -f6)/.claude"
-
 # If we're not root (could happen with custom docker run commands)
 if [ "${USER_ID}" != "0" ]; then
     # Create group if it doesn't exist


### PR DESCRIPTION
**Description:**

Don't create the claude configuration symlinks twice in the entrypoint script.

**Related Issues:**

Updates #32 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
