### PR TITLE
fix: remove path input

### DIFF
--- a/.github/workflows/generator-container-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-container-ossf-slsa3-publish.yml
@@ -91,7 +91,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          path: base/Dockerfile
           context: base/
 
       - name: Output image
@@ -185,7 +184,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          path: opencode/Dockerfile
           context: opencode/
 
       - name: Output image
@@ -279,7 +277,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          path: claude-code/Dockerfile
           context: claude-code/
 
       - name: Output image


### PR DESCRIPTION
**Description:**

Remove the `path` input to the `docker/build-push-action` because it's incorrect and not needed.

**Related Issues:**

Fixes #41 -

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
