### PR TITLE
fix: use npm clean-install in Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ export PATH="${HOME}/.local/bin:${PATH}"
 
 The following are required to run the images:
 
-- [Docker](https://docs.docker.com/engine/install/)
-- [gVisor](https://gvisor.dev/docs/user_guide/quick_start/docker/)
-- [cosign](https://docs.sigstore.dev/cosign/system_config/installation/)
+- [Docker](https://docs.docker.com/engine/install/): for running the container
+  images
+- [gVisor](https://gvisor.dev/docs/user_guide/quick_start/docker/): for
+  container runtime isolation
+- [cosign](https://docs.sigstore.dev/cosign/system_config/installation/): for
+  image verification
 
 ## Usage
 
@@ -43,7 +46,9 @@ Using the `opencode` launcher script is recommended. This will verify and run
 the latest `opencode` image with the correct parameters. The local state is
 stored in `~/.local/share/opencode-docker`.
 
-The launcher script will run the image with roughly the following command:
+The launcher script will run the image with roughly the following command. The
+project you wish to give access to `opencode` should be mounted to `/workspace`
+inside the container.
 
 ```bash
 OPENCODE_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/opencode-docker"
@@ -65,7 +70,9 @@ Using the `claude` launcher script is recommended. This will verify and run
 the latest `claude-code` image with the correct parameters. The local state is
 stored in `~/.local/share/claude-code-docker`.
 
-The launcher script will run the image with roughly the following command:
+The launcher script will run the image with roughly the following command. The
+project you wish to give access to `claude` should be mounted to `/workspace`
+inside the container.
 
 ```bash
 CLAUDE_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/claude-code-docker"

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -81,5 +81,4 @@ RUN url="https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz"; \
 
 COPY entrypoint.sh /entrypoint.sh
 
-WORKDIR /workspace
 ENTRYPOINT ["/entrypoint.sh"]

--- a/claude-code/Dockerfile
+++ b/claude-code/Dockerfile
@@ -17,10 +17,12 @@ FROM ghcr.io/ianlewis/coding-assistant-docker-images-base:latest@sha256:96ecdb55
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 
-RUN npm install --prefix /app --no-audit --no-fund --omit=dev /app
+WORKDIR /app
+RUN npm clean-install --no-fund --omit=dev
 
 COPY config.sh /config.sh
 
 ENV PATH="/app/node_modules/.bin:$PATH"
 
+WORKDIR /workspace
 CMD ["claude"]

--- a/opencode/Dockerfile
+++ b/opencode/Dockerfile
@@ -17,10 +17,12 @@ FROM ghcr.io/ianlewis/coding-assistant-docker-images-base:latest@sha256:96ecdb55
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 
-RUN npm install --prefix /app --no-audit --no-fund --omit=dev /app
+WORKDIR /app
+RUN npm clean-install --no-fund --omit=dev
 
 COPY config.sh /config.sh
 
 ENV PATH="/app/node_modules/.bin:$PATH"
 
+WORKDIR /workspace
 CMD ["opencode"]


### PR DESCRIPTION
**Description:**

Use `npm clean-install` to pin dependencies inside the container.

**Related Issues:**

Fixes #81 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
