### PR TITLE
feat: use the verified image sha to run the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The following are required to run the images:
   images
 - [gVisor](https://gvisor.dev/docs/user_guide/quick_start/docker/): for
   container runtime isolation
-- [cosign](https://docs.sigstore.dev/cosign/system_config/installation/): for
+- [`cosign`](https://docs.sigstore.dev/cosign/system_config/installation/): for
   image verification
+- [`jq`](https://stedolan.github.io/jq/download/): for parsing JSON
 
 ## Usage
 

--- a/bin/claude
+++ b/bin/claude
@@ -43,6 +43,13 @@ if ! command -v cosign >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is not installed. Please install jq first." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "https://jqlang.org/download/" >&2
+    exit 1
+fi
+
 CLAUDE_CODE_IMAGE="ghcr.io/ianlewis/claude-code"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"

--- a/bin/claude
+++ b/bin/claude
@@ -56,15 +56,22 @@ if [ ! -f "${CLAUDE_DATA_HOME}/claude.json" ]; then
     echo "{}" >"${CLAUDE_DATA_HOME}/claude.json"
 fi
 
-cosign verify-attestation \
+verified_sha=$(cosign verify-attestation \
     --type slsaprovenance \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
     --policy ~/.config/coding-assistant-docker-images/policy.cue \
-    "${CLAUDE_CODE_IMAGE}"
+    "${CLAUDE_CODE_IMAGE}" | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256')
+
+if [ -z "${verified_sha}" ]; then
+    echo "Failed to verify the image signature." >&2
+    exit 1
+fi
+
+echo "Verified image: ${CLAUDE_CODE_IMAGE}:sha256:${verified_sha}"
 
 # Ensure we have the latest image
-docker pull "${CLAUDE_CODE_IMAGE}"
+docker pull "${CLAUDE_CODE_IMAGE}@sha256:${verified_sha}"
 
 docker run \
     --rm \
@@ -75,4 +82,4 @@ docker run \
     --volume "$(pwd):/workspace" \
     --volume "${CLAUDE_DATA_HOME}/claude.json:/claude.json" \
     --volume "${CLAUDE_DATA_HOME}:/claude" \
-    "${CLAUDE_CODE_IMAGE}" claude "$@"
+    "${CLAUDE_CODE_IMAGE}@sha256:${verified_sha}" claude "$@"

--- a/bin/claude
+++ b/bin/claude
@@ -77,7 +77,6 @@ docker run \
     --rm \
     --interactive \
     --tty \
-    --name claude-code \
     --runtime runsc \
     --volume "$(pwd):/workspace" \
     --volume "${CLAUDE_DATA_HOME}/claude.json:/claude.json" \

--- a/bin/opencode
+++ b/bin/opencode
@@ -65,7 +65,6 @@ docker run \
     --interactive \
     --tty \
     --runtime runsc \
-    --name opencode \
     --volume "$(pwd):/workspace" \
     --volume "${OPENCODE_DATA_HOME}:/local" \
     "${OPENCODE_IMAGE}@sha256:${verified_sha}" opencode "$@"

--- a/bin/opencode
+++ b/bin/opencode
@@ -43,6 +43,13 @@ if ! command -v cosign >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is not installed. Please install jq first." >&2
+    echo "Please see this URL for installation instructions:" >&2
+    echo "https://jqlang.org/download/" >&2
+    exit 1
+fi
+
 OPENCODE_IMAGE="ghcr.io/ianlewis/opencode"
 
 XDG_DATA_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}"

--- a/bin/opencode
+++ b/bin/opencode
@@ -50,15 +50,15 @@ OPENCODE_DATA_HOME="${XDG_DATA_HOME}/opencode-docker"
 
 mkdir -p "${OPENCODE_DATA_HOME}"
 
-cosign verify-attestation \
+verified_sha=$(cosign verify-attestation \
     --type slsaprovenance \
     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
     --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
     --policy ~/.config/coding-assistant-docker-images/policy.cue \
-    "${OPENCODE_IMAGE}"
+    "${OPENCODE_IMAGE}" | jq -r '.payload' | base64 -d | jq -r '.subject[0].digest.sha256')
 
 # Ensure we have the latest image
-docker pull "${OPENCODE_IMAGE}"
+docker pull "${OPENCODE_IMAGE}@sha256:${verified_sha}"
 
 docker run \
     --rm \
@@ -68,4 +68,4 @@ docker run \
     --name opencode \
     --volume "$(pwd):/workspace" \
     --volume "${OPENCODE_DATA_HOME}:/local" \
-    "${OPENCODE_IMAGE}" opencode "$@"
+    "${OPENCODE_IMAGE}@sha256:${verified_sha}" opencode "$@"


### PR DESCRIPTION
**Description:**

Use the verified image sha after verification with `cosign` to run the agent container. This is to verify that the image being run is the same as the one verified.

**Related Issues:**

Fixes #82 
Fixes #105 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
