### PR TITLE
fix: only set version numbers on main

### DIFF
--- a/.github/workflows/generator-container-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-container-ossf-slsa3-publish.yml
@@ -169,7 +169,7 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
             # set the opencode package version as a tag
-            type=raw,value=${{ steps.package.outputs.version }}
+            type=raw,value=${{ steps.package.outputs.version }},enable={{is_default_branch}}
             # branch event
             type=ref,event=branch
             # tag event
@@ -262,7 +262,7 @@ jobs:
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
             # set the claude-code package version as a tag
-            type=raw,value=${{ steps.package.outputs.version }}
+            type=raw,value=${{ steps.package.outputs.version }},enable={{is_default_branch}}
             # branch event
             type=ref,event=branch
             # tag event


### PR DESCRIPTION
**Description:**

Only set version number image labels after merge to main.

**Related Issues:**

Fixes #106 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
