### PR TITLE
fix: don't use install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,15 +83,13 @@ help: ## Print all Makefile targets (this message).
 				}'
 
 install: ## Install agent launcher scripts.
-	@install \
-		-D \
-		-t "$(XDG_CONFIG_HOME)/coding-assistant-docker-images" \
-		config/policy.cue
-	@install \
-		-D \
-		-t "$(XDG_BIN)" \
-		bin/opencode \
-		bin/claude
+	@cp -f \
+		$(REPO_ROOT)/config/policy.cue \
+		$(XDG_CONFIG_HOME)/coding-assistant-docker-images/
+	@cp -f \
+		$(REPO_ROOT)/bin/opencode \
+		$(REPO_ROOT)/bin/claude \
+		$(XDG_BIN)
 
 package-lock.json: package.json
 	@npm install --package-lock-only --no-audit --no-fund


### PR DESCRIPTION
**Description:**

Don't use the `install` command since it's not portable between Linux and macOS.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
