### PR TITLE
feat: add support for linux/amd64 to the base image

### DIFF
--- a/.github/workflows/generator-container-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-container-ossf-slsa3-publish.yml
@@ -88,6 +88,9 @@ jobs:
             # pull request event
             type=ref,event=pr
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
       - name: Build and push Docker image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: build
@@ -96,6 +99,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: base/
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
         env:
           SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.timestamp }}
 
@@ -151,10 +157,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        with:
-          # NOTE: Do not use the cached binary for buildx to avoid potential
-          # cache poisoning.
-          cache-binary: false
 
       - name: Authenticate Docker
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -195,6 +197,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           context: opencode/
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
         env:
           SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.timestamp }}
 
@@ -250,10 +255,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        with:
-          # NOTE: Do not use the cached binary for buildx to avoid potential
-          # cache poisoning.
-          cache-binary: false
 
       - name: Authenticate Docker
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -296,6 +297,7 @@ jobs:
           context: claude-code/
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64
         env:
           SOURCE_DATE_EPOCH: ${{ steps.epoch.outputs.timestamp }}
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 # NOTE: the trixie-slim images are based on Debian 13 (Trixie).
-FROM node:24.11.1-trixie-slim@sha256:4623e8ac1eb5f35b0a91b85424283c1b97a416a77375dfa6a2e9bfb0b2c351c9
+FROM --platform=$BUILDPLATFORM node:24.11.1-trixie-slim@sha256:4623e8ac1eb5f35b0a91b85424283c1b97a416a77375dfa6a2e9bfb0b2c351c9
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 ENV PATH=/usr/local/go/bin:$PATH
 


### PR DESCRIPTION
**Description:**

Add support for building the base image as a multi-platform Docker image with support for `linux/amd64`.

**Related Issues:**

Updates #154 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Add unit tests if applicable.
- [x] Update documentation if applicable.
- [x] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
